### PR TITLE
Add support for format strings.

### DIFF
--- a/lib/logmagic.js
+++ b/lib/logmagic.js
@@ -71,6 +71,20 @@ function buildLogMethod(level, callback) {
   }
 }
 
+function applyFormatting(message, obj) {
+  function replaceFunction(str, p1) {
+    if (obj.hasOwnProperty(p1)) {
+      return obj[p1];
+    }
+
+    return p1;
+  }
+
+  var regex = new RegExp(/\$\{(.*?)\}/g);
+  message = message.replace(regex, replaceFunction);
+  return message;
+}
+
 function nullLogger() {
   /* Intentionally blank. */
 }
@@ -170,8 +184,8 @@ exports.route = function(match, loglevel, sinkname) {
   /* This is just here for initial dev work, REMOVE ME */
   exports.registerSink("console", function(level, message, obj) {
     if (obj) {
-      /* TODO: improve */
-      console.log(message + " " + JSON.stringify(obj));
+      message = applyFormatting(message, obj);
+      console.log(message);
     }
     else {
       console.log(message);


### PR DESCRIPTION
``` javascript
log.error("Accepts format strings too ${SOME_VAR}", {SOME_VAR: "myvalue"});
```

`Accepts format strings too ${SOME_VAR}`  -> `Accepts format strings too myvalue`

Should mostly work :)
