### PR TITLE
lib: graylog: don't create an _id field

### DIFF
--- a/lib/graylog.js
+++ b/lib/graylog.js
@@ -83,6 +83,14 @@ exports.logstr = function(module, level, message, obj) {
         if (i == 'full_message') {
           l['full_message'] = obj[i];
         }
+        /* Avoid getting a warning from graylog:
+         *
+         * WARN : org.graylog2.messagehandlers.syslog.SyslogEventHandler - \
+         * Client tried to override _id field! Skipped field, but still storing message.
+         */
+        else if (i == 'id') {
+          l["_objid"] = obj[i];
+        }
         else {
           l["_" + i] = obj[i];
         }

--- a/tests/t.js
+++ b/tests/t.js
@@ -11,7 +11,7 @@ logmagic.route("__root__", logmagic.TRACE1, "graylog2-stderr");
 log.trace("testing trace v1", {slug: 1});
 
 log = logmagic.local('mylib.foo.cars');
-log.trace("hello world", {counter: 33, account_id: 42, txnid: "fxxxxx"});
+log.trace("hello world", {counter: 33, account_id: 42, txnid: "fxxxxx", id: "i'm an id, screwing stuff up"});
 logmagic.addRewriter(function(modulename, level, msg, extra) {
   if (extra.request) {
     extra.accountId = extra.request.account.id;


### PR DESCRIPTION
_id screws up graylog, don't do it.
