### PR TITLE
feat(graylog): get FQDN from process.env

### DIFF
--- a/lib/graylog.js
+++ b/lib/graylog.js
@@ -15,11 +15,12 @@
  *
  */
 
-var os = require('os');
+var os = require('os'),
+    host = process.env.FQDN || os.hostname();
 
 var logobj = {
   version: "1.0",
-  host: os.hostname(),
+  host: host,
   timestamp: null,
   short_message: null,
   full_message: null,


### PR DESCRIPTION
Node's os.hostname() only returns hostnames, not fqdns.

This allows one to override the host attribute in gelf lines by setting the FQDN environment variable (to `hostname -f` or any other value).

```bash
$ export FQDN=`hostname -f`
$ exec node myapp.js
```