### PR TITLE
Add modulename to console.js write for parity with graylog's 'facility'

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -95,6 +95,7 @@ function clog(options) {
 
       write(color(levels.strings[level]) + " " + m + " " + message + " ");
 
+      kvout(color('facility'), modulename);
       if (obj) {
         var keys = Object.keys(obj);
         if (options.disable_sort) {


### PR DESCRIPTION
It will be sweet to distinguish log messages in the browser by which module they're from.