### PR TITLE
Remove moment.js dependency. 

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -15,7 +15,6 @@
  *
  */
 
-var moment = require('moment');
 var chalk = require('chalk');
 
 var levels = require('./levels');
@@ -82,7 +81,7 @@ function clog(options) {
   var kvout = out;
   if (useColor) {
     return function(modulename, level, message, obj) {
-      var m = moment().format("YYYY-MM-DDTHH:mm:ssZ");
+      var m = new Date().toISOString();
       var color = chalk.blue;
 
       if (level >= levels.DEBUG) {
@@ -112,7 +111,7 @@ function clog(options) {
 
   }
   return function(modulename, level, message, obj) {
-    var m = moment().format("YYYY-MM-DDTHH:mm:ssZ");
+    var m = new Date().toISOString();
 
     kvout("time", m);
     kvout("level", levels.strings[level]);

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
-    "moment": "^2.10.2"
+    "chalk": "^1.0.0"
   },
   "devDependencies": {
     "jsfmt": "^0.4.1"


### PR DESCRIPTION
Use Date().toISOString() to format timestamps.